### PR TITLE
v1 of the plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.7-buster
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - deps-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "dev-requirements.txt" }}
+            - deps-master-{{ checksum "setup.py" }}-{{ checksum "dev-requirements.txt" }}
+      - run:
+          name: Install test deps
+          command: |
+            # Use a virtual env to encapsulate everything in one folder for caching
+            python -m venv .venv
+            . .venv/bin/activate
+            pip install -r dev-requirements.txt
+      - save_cache:
+          key: deps-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "dev-requirements.txt" }}
+          paths:
+            - ".venv"
+            - "~/.cache"
+      - run:
+          name: run_tests
+          command: |
+            . .venv/bin/activate
+            mkdir test-results
+            pytest --junitxml=test-results/junit.xml
+      - store_test_results:
+          path: test-results
+
+      - store_artifacts:
+          path: test-results

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+sdist/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Testing
+/.venv/
+testdb.sqlite

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# astronomer-airflow-version-check
+
+An Apache Airflow plugin that will periodically (default, once per day) check
+if there is a new version of Astronomer's Certified Airflow and display a
+message in the UI
+
+## Settings
+
+This plugin looks at the following settings under the `astronomer` section of
+the Airflow config. The easiest way of setting this is via environment
+variables prefixed with `AIRFLOW__ASTRONOMER__`
+
+- `update_check_interval`
+
+  Number of seconds between each update check. Default 86400 (one day). Set to
+  0 to disable update checks
+
+- `update_check_timeout`
+
+  HTTP timeout for requesting update document. Default 60
+
+- `update_url`
+
+  URL to request to find out about more udpates. Default to `updates.astronomer.io`

--- a/astronomer/airflow/version_check/models.py
+++ b/astronomer/airflow/version_check/models.py
@@ -1,0 +1,87 @@
+import datetime
+import os
+import logging
+import threading
+from typing import Optional
+
+import sqlalchemy.ext
+from airflow.models import Base
+from airflow.utils.db import create_session
+from airflow.utils.net import get_hostname
+from airflow.utils.timezone import utcnow
+from airflow.utils.sqlalchemy import UtcDateTime
+from sqlalchemy import Boolean, Column, Index, Text, or_
+
+log = logging.getLogger(__name__)
+
+
+class AstronomerVersionCheck(Base):
+    __tablename__ = "astro_version_check"
+    singleton = Column(Boolean, default=True, nullable=False, primary_key=True)
+
+    # For infomration only
+    last_checked = Column(UtcDateTime(timezone=True))
+    last_checked_by = Column(Text)
+
+    @classmethod
+    def ensure_singleton(cls):
+        """
+        Ensure that the singleton row exists in this table
+        """
+        with create_session() as session:
+            try:
+                session.bulk_save_objects([cls(singleton=True)])
+            except sqlalchemy.exc.IntegrityError:
+                # Already exists, we're good
+                session.rollback()
+
+    @classmethod
+    def acquire_lock(cls, check_interval, session):  # type: (datetime.timedelta, sqlalchemy.Session) -> Optional[AstronomerVersionCheck]
+        """
+        Aquire an exclusive lock to perform an update check if the check is due
+        and if another check is not already in progress.
+
+        We use the database to hold the lock for as long as this transaction is open using `FOR UPDATE SKIP LOCKED`.
+
+        This method will either return a row meaning the check is due and we
+        have acuired the lock. The lock will be held for the duration of the
+        database transaction -- be careful to to close this before you are
+        done!
+
+        This will throw an error if the lock is held by another transaction.
+        """
+        now = utcnow()
+
+        return session.query(cls).filter(
+            cls.singleton.is_(True),
+            or_(cls.last_checked.is_(None), cls.last_checked <= now - check_interval),
+        ).with_for_update(nowait=True).one_or_none()
+
+    @classmethod
+    def get(cls, session):
+        """
+        Return the update tracking row
+        """
+        return session.query(cls).filter(cls.singleton.is_(True)).one()
+
+    @staticmethod
+    def host_identifier():
+        return "{hostname}-{pid}#{tid}".format(
+            hostname=get_hostname(),
+            pid=os.getpid(),
+            tid=threading.get_ident()
+        )
+
+
+class AstronomerAvailableVersion(Base):
+    __tablename__ = "astro_available_version"
+    version = Column(Text, nullable=False, primary_key=True)
+    level = Column(Text, nullable=False)
+    date_released = Column(UtcDateTime(timezone=True), nullable=False)
+    description = Column(Text)
+    url = Column(Text)
+    hidden_from_ui = Column(Boolean, default=False, nullable=False)
+
+    __table_args__ = (
+        Index('idx_astro_available_version_hidden', hidden_from_ui),
+    )

--- a/astronomer/airflow/version_check/plugin.py
+++ b/astronomer/airflow/version_check/plugin.py
@@ -1,0 +1,62 @@
+import functools
+import logging
+
+from airflow.plugins_manager import AirflowPlugin
+from airflow.utils.db import create_session
+
+from .update_checks import UpdateAvailableBlueprint
+
+__version__ = "1.0.0"
+
+log = logging.getLogger(__name__)
+
+
+class AstronomerVersionCheckPlugin(AirflowPlugin):
+    name = "astronomer_version_check"
+
+    flask_blueprints = [UpdateAvailableBlueprint()]
+    @staticmethod
+    def add_before_call(mod_or_cls, target, pre_fn):
+        fn = getattr(mod_or_cls, target)
+
+        @functools.wraps(fn)
+        def run_before(*args, **kwargs):
+            pre_fn()
+            fn(*args, **kwargs)
+
+        setattr(mod_or_cls, target, run_before)
+
+    @classmethod
+    def on_load(cls, *args, **kwargs):
+        # Hook in to various places in Airflow in a slightly horrible way -- by
+        # using functools.wraps and replacing the function.
+
+        import airflow.utils.db
+        import airflow.jobs.scheduler_job
+        cls.add_before_call(airflow.utils.db, 'upgradedb', cls.create_db_tables)
+        cls.add_before_call(airflow.jobs.scheduler_job.SchedulerJob, '_execute_helper', cls.start_update_thread)
+
+    @classmethod
+    def start_update_thread(cls):
+        from .models import AstronomerVersionCheck
+        from .update_checks import CheckThread
+
+        AstronomerVersionCheck.ensure_singleton()
+        CheckThread().start()
+
+    @classmethod
+    def create_db_tables(cls):
+        from .models import AstronomerAvailableVersion, AstronomerVersionCheck
+        with create_session() as session:
+            try:
+                engine = session.get_bind(mapper=None, clause=None)
+                if not engine.has_table(AstronomerVersionCheck.__tablename__):
+                    log.info("Creating DB tables for %s", __name__)
+                    metadata = AstronomerVersionCheck.metadata
+                    metadata.create_all(bind=engine, tables=[
+                        metadata.tables[c.__tablename__] for c in [AstronomerVersionCheck, AstronomerAvailableVersion]
+                    ])
+                    log.info("Created")
+            except Exception:
+                log.exception("Error creating tables")
+                exit(1)

--- a/astronomer/airflow/version_check/static/update-notice.css
+++ b/astronomer/airflow/version_check/static/update-notice.css
@@ -1,0 +1,3 @@
+.cea-update-notice button {
+  float: right;
+}

--- a/astronomer/airflow/version_check/static/update-notice.js
+++ b/astronomer/airflow/version_check/static/update-notice.js
@@ -1,0 +1,14 @@
+"use strict";
+
+$(document).ready(function() {
+  $(".cea-update-notice button").on("click", function() {
+    var el = $(this);
+    el.prop( "disabled", true );
+    $.post(el.data('href')).done(() => {
+      el.parents(".cea-update-notice").slideUp();
+    }).fail(() => {
+      alert("There was a problem submitting this request");
+      el.prop( "disabled", false );
+    })
+  });
+});

--- a/astronomer/airflow/version_check/templates/astro-baselayout.html
+++ b/astronomer/airflow/version_check/templates/astro-baselayout.html
@@ -1,0 +1,14 @@
+{% extends airflow_base_template %}
+{% block messages %}
+    {% include "update-available.html" %}
+    {{ super() }}
+{% endblock %}
+{% block head_css %}
+  {{ super() }}
+  <link href="{{ url_for('UpdateAvailableView.static', filename='update-notice.css') }}" rel="stylesheet">
+{% endblock %}
+
+{% block head_js %}
+  {{ super() }}
+  <script src="{{ url_for('UpdateAvailableView.static', filename='update-notice.js') }}"></script>
+{% endblock %}

--- a/astronomer/airflow/version_check/templates/update-available.html
+++ b/astronomer/airflow/version_check/templates/update-available.html
@@ -1,0 +1,28 @@
+{% if current_user.is_authenticated and cea_update_available %}
+  {% set level = "error" if cea_update_available.level == "critical" else "warning" %}
+  <div class="alert alert-{{ level }} cea-update-notice">
+    {% if "can_dismiss" | is_item_visible("UpdateAvailable") %}
+      <button data-href="{{ url_for('UpdateAvailable.dismiss', version=cea_update_available.version) }}" title="Ignore this update, and hide this message from all users">&times; Ignore this update</button>
+    {% endif %}
+    <p><strong>A new version of Astronomer CEA is available.</strong></p>
+    <p>
+    {% if cea_update_available.url %}
+      <a href="{{ cea_update_available.url }}">
+    {% endif %}
+        Version {{ cea_update_available.version }}
+    {% if cea_update_available.url %}
+      </a>
+    {% endif %}
+      was released on
+      <time datetime="{{ cea_update_available.date_released.isoformat() }}">{{ cea_update_available.date_released.strftime("%Y-%m-%d") }}</time>
+      {%- if cea_update_available.level == "critical" %}
+        and this is a critical fix
+      {%- endif -%}
+      .
+    </p>
+    {% if cea_update_available.description %}
+      <p>{{ cea_update_available.description }}</p>
+    {% endif %}
+  </div>
+{% endif %}
+

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,8 @@
+# Requirements that can't be expressed in setup.py
+
+# We need our back-ported fixes to Airflow for our tests to pass
+# We need to specify the astro version here, otherwise it would install the one from pypi repo instead
+--find-links=https://pip.astronomer.io/simple/
+apache-airflow==1.10.7+astro.6
+
+-e .[test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel", "pytest-runner~=4.0"]
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[aliases]
+test=pytest
+
+[flake8]
+max-line-length = 160
+application-import-names=astronomer
+import-order-style = google
+
+[tool:pytest]
+addopts=--tb=short --flake8
+junit_family=xunit2

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,88 @@
+# Copyright 2020 Astronomer Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import re
+
+from setuptools import find_namespace_packages, setup
+
+
+def fpath(*parts):
+    return os.path.join(os.path.dirname(__file__), *parts)
+
+
+def read(*parts):
+    return open(fpath(*parts)).read()
+
+
+def desc():
+    return read('README.md')
+
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+def find_version(*paths):
+    version_file = read(*paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+
+setup(
+    name='astronomer-airflow-version-check',
+    version=find_version('astronomer', 'airflow', 'version_check', 'plugin.py'),
+    url='https://github.com/astronomer/astronomer-airflow-version-check',
+    license='Apache2',
+    author='astronomerio',
+    author_email='humans@astronomer.io',
+    description='Periodically check for new releases of Astronomer Certified Airflow',
+    long_description=desc(),
+    long_description_content_type="text/markdown",
+    packages=find_namespace_packages(exclude='tests'),
+    package_data={'': ['LICENSE']},
+    namespace_packages=['astronomer', 'astronomer.airflow'],
+    include_package_data=True,
+    zip_safe=True,
+    platforms='any',
+    entry_points={
+        'airflow.plugins': ['astronomer_version_check=astronomer.airflow.version_check.plugin:AstronomerVersionCheckPlugin']
+    },
+    install_requires=[
+        'apache-airflow>=1.10.5',
+        'lazy_object_proxy~=1.3',
+        'packaging>=20.0',
+    ],
+    setup_requires=[
+        'pytest-runner~=4.0',
+    ],
+    tests_require=[
+        'astronomer-airflow-version-check[test]',
+    ],
+    extras_require={
+        'test': [
+            'pytest',
+            'pytest-flask',
+            'pytest-mock',
+            'pytest-flake8',
+        ],
+    },
+    classifiers=[
+        'Environment :: Web Environment',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Programming Language :: Python :: 3',
+    ],
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,90 @@
+import os
+
+from flask.testing import FlaskClient
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "login_as")
+
+
+@pytest.yield_fixture
+def client(app, user, request):
+    """The test client, optionally logged in as a user of the given role
+
+        @pytest.mark.login_as('Admin')
+        def test_while_logged_in(client):
+            ....
+
+        def test_while_anon(clinet):
+            ...
+
+    """
+    marker = request.node.get_closest_marker('login_as')
+    user_obj = None
+
+    if marker:
+        user_obj = user(marker.args[0])
+
+    with app.test_client(user=user_obj) as client:
+        yield client
+
+
+@pytest.fixture(scope='module')
+def app():
+    os.environ['AIRFLOW__CORE__SQL_ALCHEMY_CONN'] = 'sqlite:///testdb.sqlite'
+    os.environ['AIRFLOW__WEBSERVER__RBAC'] = 'True'
+    from airflow.utils.db import initdb
+    from airflow.www_rbac.app import create_app
+
+    initdb(rbac=True)
+    app, _ = create_app(testing=True)
+    app.test_client_class = FlaskLoginClient
+    return app
+
+
+@pytest.fixture()
+def appbuilder(app):
+    return app.appbuilder
+
+
+@pytest.fixture
+def user(appbuilder):
+    def _user(role):
+        username = role.lower()
+
+        user = appbuilder.sm.find_user(username=username)
+        if user:
+            return user
+
+        txn2 = appbuilder.session.begin_nested()
+        role_obj = appbuilder.sm.find_role(role)
+        if not appbuilder.sm.add_user(username, "Local", role, f'{username}@fab.org', role_obj, role.lower()):
+            raise RuntimeError("Error creating test user")
+        if txn2.is_active:
+            # add_user calls commit(), but lets be safe and ensure it does
+            txn2.commit()
+        user = appbuilder.sm.find_user(username=username)
+
+        return user
+    return _user
+
+
+class FlaskLoginClient(FlaskClient):
+    """
+    A Flask test client that knows how to log in users
+    using the Flask-Login extension.
+
+    This is taken from flask-login 0.5, but right now airflow needs <0.5
+    """
+
+    def __init__(self, *args, **kwargs):
+        user = kwargs.pop("user", None)
+        fresh = kwargs.pop("fresh_login", True)
+
+        super(FlaskLoginClient, self).__init__(*args, **kwargs)
+
+        if user:
+            with self.session_transaction() as sess:
+                sess["user_id"] = user.id
+                sess["_fresh"] = fresh

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,15 @@
+from flask import url_for
+import pytest
+
+
+@pytest.mark.login_as('Admin')
+def test_logged_in(client):
+    response = client.get(url_for('Airflow.index'))
+    assert response.status_code == 200
+    assert b"update-notice.css" in response.data, "Ensure our template customizations are shown"
+
+
+def test_anon(client):
+    response = client.get(url_for('Airflow.index'))
+    assert response.status_code == 302
+    assert b"update-notice.css" not in response.data, "Don't show notice when logged out"


### PR DESCRIPTION
This plugin operates as follows:

- It uses `functools.wraps` to "hook" in to various places in Airflow
  that don't have pre-existing hook points.

  This does mean that if those function names change in the future this
  will stop working.

- It runs a thread in the scheduler process to make requests to the
  update server.

  It hooks in to airflow.jobs.scheduler_job.SchedulerJob._execute_helper
  to start the thread.

- Available updates are stored in the database for the UI to query

- The UI display is done by customizing the `appbuilder.base_template`,
  as again, there aren't enough hook points to inject our front end code
  any other way. This needs AIRFLOW-6733 and AIRFLOW-6734 to work.

- This notice is shown for all (logged in) users, but the dismiss button is
  only visible for admins.

- There aren't any tests right now :(