### PR TITLE
Automatically deploy tagged releases to bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,33 @@
 version: 2.1
+
+parameters:
+  deploy_bucket:
+    type: string
+    default: "pip.astronomer.io"
+
+workflows:
+  build_and_deploy:
+    jobs:
+      - build:
+          filters:  # required since `deploy` has tag filters AND requires `build`
+            tags:
+              only: /.*/
+      - publish:
+          requires: [build]
+          # Run this stage only for version-number tagged builds
+          filters:
+            tags:
+              only: /^\d+[.\d]+.*/
+            branches:
+              ignore: /.*/
 jobs:
   build:
     docker:
       - image: circleci/python:3.7-buster
     steps:
       - checkout
-      - restore_cache:
+      - &restore_venv
+        restore_cache:
           keys:
             - deps-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "dev-requirements.txt" }}
             - deps-master-{{ checksum "setup.py" }}-{{ checksum "dev-requirements.txt" }}
@@ -27,8 +49,50 @@ jobs:
             . .venv/bin/activate
             mkdir test-results
             pytest --junitxml=test-results/junit.xml
+      - run:
+          name: build_wheel
+          command: |
+            . .venv/bin/activate
+            python3 setup.py sdist bdist_wheel
       - store_test_results:
           path: test-results
 
+      - persist_to_workspace:
+          root: .
+          paths:
+            dist/*
       - store_artifacts:
           path: test-results
+
+  publish:
+    docker:
+      - image: gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+    steps:
+      - checkout
+      - *restore_venv
+      - run:
+          name: verify tag
+          command: |-
+            # Because we are running this stage in a non-standard container we
+            # need to specify the full path
+            . /home/circleci/project/.venv/bin/activate
+            python3 setup.py verify
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Checkout release-utilities
+          command: |-
+            git clone git@github.com:astronomer/pip-release-utilities.git
+      - run:
+          name: Deploy to GCS Bucket
+          # Even though there is a project field in the JSON credential, gsutil still needs a project set, so lets set pull it from it
+          command: |-
+            pip-release-utilities/gsutil-auth-helper.sh
+            gsutil -m rsync -a public-read /tmp/workspace/dist/ gs://<< pipeline.parameters.deploy_bucket >>/simple/
+      - run:
+          name: Rebuild index.html
+          command: |-
+            pip-release-utilities/build-index-page.sh "<< pipeline.parameters.deploy_bucket >>"
+      - store_artifacts:
+          path: /tmp/workspace/dist/
+          destination: dist

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 # Requirements that can't be expressed in setup.py
+wheel
 
 # We need our back-ported fixes to Airflow for our tests to pass
 # We need to specify the astro version here, otherwise it would install the one from pypi repo instead


### PR DESCRIPTION
This uses a new helper repo I created https://github.com/astronomer/pip-release-utilities -- as we have three or so modules deploying to there and we want to share some of the deploy steps.