### PR TITLE
Fix installing of AC in our tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ wheel
 
 # We need our back-ported fixes to Airflow for our tests to pass
 # We need to specify the astro version here, otherwise it would install the one from pypi repo instead
---find-links=https://pip.astronomer.io/simple/
-apache-airflow==1.10.7+astro.6
+--extra-index-url=https://pip.astronomer.io/simple/
+astronomer-certified==1.10.7.*
 
 -e .[test]


### PR DESCRIPTION
To work on 1.10.7 we need our fork/back-ported fixes.

The old way of installing didn't work since we made our pip repo behave more like a proper one.