### PR TITLE
Don't error if update check tables don't exist.

### DIFF
--- a/astronomer/airflow/version_check/plugin.py
+++ b/astronomer/airflow/version_check/plugin.py
@@ -41,6 +41,13 @@ class AstronomerVersionCheckPlugin(AirflowPlugin):
         from .models import AstronomerVersionCheck
         from .update_checks import CheckThread
 
+        with create_session() as session:
+            engine = session.get_bind(mapper=None, clause=None)
+            if not engine.has_table(AstronomerVersionCheck.__tablename__):
+                log.warn("AstronomerVersionCheck tables are missing (plugin not installed at upgradedb "
+                         "time?). No update checks will be performed")
+                return
+
         AstronomerVersionCheck.ensure_singleton()
         CheckThread().start()
 

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -266,6 +266,12 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
         if not hasattr(app, 'appbuilder'):
             return
 
+        with create_session() as session:
+            engine = session.get_bind(mapper=None, clause=None)
+            if not engine.has_table(AstronomerVersionCheck.__tablename__):
+                self.log.warn("AstronomerVersionCheck tables are missing (plugin not installed at upgradedb time?) - no update checks will be performed")
+                return
+
         self.airflow_base_template = app.appbuilder.base_template
 
         if app.appbuilder.base_template == "airflow/master.html":

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -263,13 +263,15 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
         Re-configure Flask to use our customized layout (that includes the call-home JS)
         Called by Flask when registering the blueprint to the app
         """
+        from .models import AstronomerVersionCheck
         if not hasattr(app, 'appbuilder'):
             return
 
         with create_session() as session:
             engine = session.get_bind(mapper=None, clause=None)
             if not engine.has_table(AstronomerVersionCheck.__tablename__):
-                self.log.warn("AstronomerVersionCheck tables are missing (plugin not installed at upgradedb time?) - no update checks will be performed")
+                self.log.warn("AstronomerVersionCheck tables are missing (plugin not installed at upgradedb "
+                              "time?). No update checks will be performed")
                 return
 
         self.airflow_base_template = app.appbuilder.base_template


### PR DESCRIPTION
This makes it easier for us to install in older versions of our platform
without it breaking things. (Due to other limitations we haven't been
running migrations from the user image, but the stock/default image
which likely won't have this plugin installed.)