### PR TITLE
Select if unique constraint row exists

### DIFF
--- a/astronomer/airflow/version_check/models.py
+++ b/astronomer/airflow/version_check/models.py
@@ -29,6 +29,11 @@ class AstronomerVersionCheck(Base):
         Ensure that the singleton row exists in this table
         """
         with create_session() as session:
+            # To keep PG logs quieter (it shows an ERROR for the PK violation),
+            # we try and select first
+            if session.query(cls).get(singleton=True) is not None:
+                return
+
             try:
                 session.bulk_save_objects([cls(singleton=True)])
             except sqlalchemy.exc.IntegrityError:

--- a/astronomer/airflow/version_check/plugin.py
+++ b/astronomer/airflow/version_check/plugin.py
@@ -15,6 +15,7 @@ class AstronomerVersionCheckPlugin(AirflowPlugin):
     name = "astronomer_version_check"
 
     flask_blueprints = [UpdateAvailableBlueprint()]
+
     @staticmethod
     def add_before_call(mod_or_cls, target, pre_fn):
         fn = getattr(mod_or_cls, target)


### PR DESCRIPTION
Without doing this we will show

> ERROR: duplicate key value violates unique constraint "astro_version_check_pkey"

in the Postgres server logs -- nothing is wrong with this, but it isn't
great to show errors, especially in local environments where users might notice this.

(We still need the try/except around the bulk save as two processes
could race to create it still.)