### PR TITLE
Set hidden_from_ui=True for Old Versions

### DIFF
--- a/astronomer/airflow/version_check/models.py
+++ b/astronomer/airflow/version_check/models.py
@@ -43,13 +43,13 @@ class AstronomerVersionCheck(Base):
     @classmethod
     def acquire_lock(cls, check_interval, session):  # type: (datetime.timedelta, sqlalchemy.Session) -> Optional[AstronomerVersionCheck]
         """
-        Aquire an exclusive lock to perform an update check if the check is due
+        Acquire an exclusive lock to perform an update check if the check is due
         and if another check is not already in progress.
 
         We use the database to hold the lock for as long as this transaction is open using `FOR UPDATE SKIP LOCKED`.
 
         This method will either return a row meaning the check is due and we
-        have acuired the lock. The lock will be held for the duration of the
+        have acquired the lock. The lock will be held for the duration of the
         database transaction -- be careful to to close this before you are
         done!
 

--- a/astronomer/airflow/version_check/models.py
+++ b/astronomer/airflow/version_check/models.py
@@ -31,7 +31,7 @@ class AstronomerVersionCheck(Base):
         with create_session() as session:
             # To keep PG logs quieter (it shows an ERROR for the PK violation),
             # we try and select first
-            if session.query(cls).get(singleton=True) is not None:
+            if session.query(cls).get({"singleton": True}) is not None:
                 return
 
             try:

--- a/astronomer/airflow/version_check/plugin.py
+++ b/astronomer/airflow/version_check/plugin.py
@@ -45,8 +45,8 @@ class AstronomerVersionCheckPlugin(AirflowPlugin):
         with create_session() as session:
             engine = session.get_bind(mapper=None, clause=None)
             if not engine.has_table(AstronomerVersionCheck.__tablename__):
-                log.warn("AstronomerVersionCheck tables are missing (plugin not installed at upgradedb "
-                         "time?). No update checks will be performed")
+                log.warning("AstronomerVersionCheck tables are missing (plugin not installed at upgradedb "
+                            "time?). No update checks will be performed")
                 return
 
         AstronomerVersionCheck.ensure_singleton()

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -62,13 +62,14 @@ class CheckThread(threading.Thread, LoggingMixin):
 
         self.ac_version = get_ac_version()
 
+        self.hide_old_versions()
+
         # On start up sleep for a small amount of time (to give the scheduler time to start up properly)
         rand_delay = random.uniform(5, 20)
         self.log.debug("Waiting %d seconds before doing first check", rand_delay)
         time.sleep(rand_delay)
         while True:
             try:
-                self.hide_old_versions()
                 update_available, wake_up_in = self.check_for_update()
                 if update_available == UpdateResult.SUCCESS_UPDATE_AVAIL:
                     self.log.info("A new version of Astronomer Certified Airflow is available")
@@ -230,10 +231,7 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
                 AstronomerAvailableVersion.hidden_from_ui.is_(False)
             )
 
-            ac_version = version.parse(get_ac_version())
             for rel in sorted(available_releases, key=lambda v: version.parse(v.version), reverse=True):
-                if ac_version >= version.parse(rel.version):
-                    return None
                 # For simplicity in the UI, only show the latest version that is available
                 return {
                     'level': rel.level,

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -26,7 +26,7 @@ except ImportError:
     from airflow.www.decorators import action_logging
 
 
-# Code is placed in this file as the default Airlow logging config shows the
+# Code is placed in this file as the default Airflow logging config shows the
 # file name (not the logger name) so this prefixes our log messages with
 # "update_checks.py"
 


### PR DESCRIPTION
depends on https://github.com/astronomer/astronomer-airflow-version-check/pull/13

(not https://github.com/astronomer/astronomer-airflow-version-check/pull/13 is enough to fix https://github.com/astronomer/issues/issues/1561)

I have tested this locally and on staging.