### PR TITLE
Add more data to UserAgent on Updater Service requests

### DIFF
--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -3,10 +3,12 @@ import json
 import os
 import platform
 import random
+import sys
 import threading
 import time
 from datetime import timedelta
 
+import distro
 import lazy_object_proxy
 import pendulum
 import requests
@@ -324,6 +326,17 @@ def get_user_string_data():
             "store_serialized_dags": conf.get("core", "store_serialized_dags", fallback=None),
         }
     }
+
+    if sys.platform.startswith("linux"):
+        distro_infos = dict(filter(
+            lambda x: x[1],
+            zip(["name", "version", "id"], distro.linux_distribution()),
+        ))
+        if distro_infos:
+            data["distro"] = distro_infos
+
+    if sys.platform.startswith("darwin") and platform.mac_ver()[0]:
+        data["distro"] = {"name": "macOS", "version": platform.mac_ver()[0]}
 
     if platform.system():
         data.setdefault("system", {})["name"] = platform.system()

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
     },
     install_requires=[
         'astronomer-certified>=1.10.7',
+        'distro~=1.5',
         'lazy_object_proxy~=1.3',
         'packaging>=20.0',
     ],


### PR DESCRIPTION
With this change:

```
185.80.118.24 - "GET https://updates.astronomer.io/astronomer-certified?site=http%3A%2F%2Flocalhost%3A8080" 200 3051 "airflow/1.10.10.post3 {"airflow_configs":{"executor":"LocalExecutor","store_serialized_dags":"False"},"ci":null,"cpu":"x86_64","distro":{"name":"Alpine Linux","version":"3.10.5"},"implementation":{"name":"CPython"},"python":"3.7.7","system":{"name":"Linux","release":"4.19.76-linuxkit"}}"
```

![image](https://user-images.githubusercontent.com/8811558/88332576-ae99fc80-cd26-11ea-90de-ef04fccc0b8c.png)
