### PR TITLE
Updated text type of primary key for version table

### DIFF
--- a/astronomer/airflow/version_check/models.py
+++ b/astronomer/airflow/version_check/models.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import sqlalchemy.ext
 from airflow.models import Base
-from airflow.utils.db import create_session
+from airflow.utils.db import create_session, provide_session
 from airflow.utils.net import get_hostname
 from airflow.utils.timezone import utcnow
 from airflow.utils.sqlalchemy import UtcDateTime
@@ -78,9 +78,22 @@ class AstronomerVersionCheck(Base):
         )
 
 
+@provide_session
+def _get_version_column_type(session):
+    """
+    To avoid MySQL/MariaDB errors when using TEXT with Primary Key
+    Details: https://stackoverflow.com/questions/1827063/mysql-error-key-specification-without-a-key-length
+    """
+    if session.bind.dialect.name == "mysql":
+        col_type = String(255)
+    else:
+        col_type = Text
+    return col_type
+
+
 class AstronomerAvailableVersion(Base):
     __tablename__ = "astro_available_version"
-    version = Column(String(255), nullable=False, primary_key=True)
+    version = Column(_get_version_column_type(), nullable=False, primary_key=True)
     level = Column(Text, nullable=False)
     date_released = Column(UtcDateTime(timezone=True), nullable=False)
     description = Column(Text)

--- a/astronomer/airflow/version_check/models.py
+++ b/astronomer/airflow/version_check/models.py
@@ -10,7 +10,7 @@ from airflow.utils.db import create_session
 from airflow.utils.net import get_hostname
 from airflow.utils.timezone import utcnow
 from airflow.utils.sqlalchemy import UtcDateTime
-from sqlalchemy import Boolean, Column, Index, Text, or_
+from sqlalchemy import Boolean, Column, Index, String, Text, or_
 
 log = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ class AstronomerVersionCheck(Base):
 
 class AstronomerAvailableVersion(Base):
     __tablename__ = "astro_available_version"
-    version = Column(Text, nullable=False, primary_key=True)
+    version = Column(String(255), nullable=False, primary_key=True)
     level = Column(Text, nullable=False)
     date_released = Column(UtcDateTime(timezone=True), nullable=False)
     description = Column(Text)

--- a/astronomer/airflow/version_check/plugin.py
+++ b/astronomer/airflow/version_check/plugin.py
@@ -58,7 +58,8 @@ class AstronomerVersionCheckPlugin(AirflowPlugin):
         with create_session() as session:
             try:
                 engine = session.get_bind(mapper=None, clause=None)
-                if not engine.has_table(AstronomerVersionCheck.__tablename__):
+                if not engine.has_table(AstronomerVersionCheck.__tablename__) or \
+                        not engine.has_table(AstronomerAvailableVersion.__tablename__):
                     log.info("Creating DB tables for %s", __name__)
                     metadata = AstronomerVersionCheck.metadata
                     metadata.create_all(bind=engine, tables=[


### PR DESCRIPTION
It seems like mysql doesn't like unbounded character text types as a primary key. For mysql/maria table creation fails with the following:

sqlalchemy.exc.OperationalError: (_mysql_exceptions.OperationalError) (1170, "BLOB/TEXT column 'version' used in key specification without a key length")
[SQL:
CREATE TABLE astro_available_version (
        version TEXT NOT NULL,
        level TEXT NOT NULL,
        date_released DATETIME NOT NULL,
        description TEXT,
        url TEXT,
        hidden_from_ui BOOL NOT NULL,
        PRIMARY KEY (version),
        CHECK (hidden_from_ui IN (0, 1))
)

Per this post: https://stackoverflow.com/questions/1827063/mysql-error-key-specification-without-a-key-length
I updated the primary key type from an unbounded text type to String(255) which fixes the issue.