### PR TITLE
Make the version check plugin Airflow 2.0 compatible

### DIFF
--- a/astronomer/airflow/version_check/plugin.py
+++ b/astronomer/airflow/version_check/plugin.py
@@ -35,7 +35,12 @@ class AstronomerVersionCheckPlugin(AirflowPlugin):
         import airflow.utils.db
         import airflow.jobs.scheduler_job
         cls.add_before_call(airflow.utils.db, 'upgradedb', cls.create_db_tables)
-        cls.add_before_call(airflow.jobs.scheduler_job.SchedulerJob, '_execute_helper', cls.start_update_thread)
+        try:
+            cls.add_before_call(
+                airflow.jobs.scheduler_job.SchedulerJob, '_execute_helper', cls.start_update_thread)
+        except AttributeError:
+            cls.add_before_call(
+                airflow.jobs.scheduler_job.SchedulerJob, '_run_scheduler_loop', cls.start_update_thread)
 
     @classmethod
     def start_update_thread(cls):


### PR DESCRIPTION
Fixes the following error:

```
scheduler_1 | [2020-10-14 15:53:58,711] {plugins_manager.py:155} ERROR - Failed to import plugin astronomer_version_check
scheduler_1 | Traceback (most recent call last):
scheduler_1 |   File "/usr/local/lib/python3.7/site-packages/airflow/plugins_manager.py", line 152, in load_entrypoint_plugins
scheduler_1 |     plugin_instance.on_load()
scheduler_1 |   File "/usr/local/lib/python3.7/site-packages/astronomer/airflow/version_check/plugin.py", line 38, in on_load
scheduler_1 |     cls.add_before_call(airflow.jobs.scheduler_job.SchedulerJob, '_execute_helper', cls.start_update_thread)
scheduler_1 |   File "/usr/local/lib/python3.7/site-packages/astronomer/airflow/version_check/plugin.py", line 21, in add_before_call
scheduler_1 |     fn = getattr(mod_or_cls, target)
scheduler_1 | AttributeError: type object 'SchedulerJob' has no attribute '_execute_helper'
```

