### PR TITLE
Pin attrs to less than 20.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,3 +8,5 @@ wheel
 astronomer-certified==1.10.7.*
 
 -e .[test]
+
+attrs<20.0


### PR DESCRIPTION
Without this the tests fails with since Airflow need ~=19.3:

```
[2020-10-15 14:36:35,754] {plugins_manager.py:111} ERROR - Failed to import plugin astronomer_version_check
Traceback (most recent call last):
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/airflow/plugins_manager.py", line 105, in load_entrypoint_plugins
    plugin_obj = entry_point.load()
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2461, in load
    self.require(*args, **kwargs)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2484, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 792, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (attrs 20.2.0 (/home/circleci/project/.venv/lib/python3.7/site-packages), Requirement.parse('attrs~=19.3')
```