### PR TITLE
Fix disabling update_check_interval checks

### DIFF
--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -46,7 +46,8 @@ class CheckThread(threading.Thread, LoggingMixin):
     def __init__(self):
         super().__init__(name="AstronomerCEAVersionCheckThread", daemon=True)
         # Check once a day by default
-        self.check_interval = timedelta(seconds=conf.getint("astronomer", "update_check_interval", fallback=24*60*60))
+        self.check_interval_secs = conf.getint("astronomer", "update_check_interval", fallback=24*60*60)
+        self.check_interval = timedelta(seconds=self.check_interval_secs)
         self.request_timeout = conf.getint("astronomer", "update_check_timeout", fallback=60)
         self.base_url = conf.get("webserver", "base_url")
 
@@ -60,7 +61,7 @@ class CheckThread(threading.Thread, LoggingMixin):
         Periodically check for new versions of Astronomer Certified Airflow,
         and update the AstronomerAvailableVersions table
         """
-        if self.check_interval == 0:
+        if self.check_interval_secs == 0:
             self.log.info("Update checks disabled")
             return
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,3 +10,5 @@ astronomer-certified==1.10.7.*
 -e .[test]
 
 attrs<20.0
+marshmallow-sqlalchemy==0.23.0
+marshmallow<=2.21.0


### PR DESCRIPTION
Because `self.check_interval` was a timedelta object, check with 0 resulted in False.

```
In [1]: from datetime import timedelta

In [2]: timedelta(seconds=0)
Out[2]: datetime.timedelta(0)

In [3]: timedelta(seconds=0) == 0
Out[3]: False
```