### PR TITLE
Replace 2.0 Appbuilder base template

### DIFF
--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -294,7 +294,7 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
 
         self.airflow_base_template = app.appbuilder.base_template
 
-        if app.appbuilder.base_template == "airflow/master.html":
+        if app.appbuilder.base_template in ["airflow/master.html", "airflow/main.html"]:
             app.appbuilder.base_template = "astro-baselayout.html"
         else:
             self.log.warning("Not replacing appbuilder.base_template, it didn't have the expected value. Update"


### PR DESCRIPTION
Before 2.0 the `app.appbuilder.base_template` was `airflow/master.html`. From 2.0 it is called `airflow/main.html`