### PR TITLE
Use add_view_no_menu since add_api is removed in airflow

### DIFF
--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -300,7 +300,7 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
         else:
             self.log.warning("Not replacing appbuilder.base_template, it didn't have the expected value. Update"
                              " available messages will not be visible in UI")
-        app.appbuilder.add_api(self.UpdateAvailable)
+        app.appbuilder.add_view_no_menu(self.UpdateAvailable)
         self.app_context_processor(self.new_template_vars)
 
         super().register(app, options, first_registration)


### PR DESCRIPTION
`appbuilder.add_api` has been removed in airflow. Luckily, it's
a wrapper around `appbuilder.add_view_no_menu`
Airflow PR: https://github.com/apache/airflow/pull/20487

Closes: https://github.com/astronomer/issues-airflow/issues/153