### PR TITLE
Version 1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 1.0.8
+
+Released 2022-01-24
+
+- Use `add_view_no_menu since add_api` is removed in airflow (#24)
+- Fix CI issues and Bump dev requirements (#26)
+
 ## Version 1.0.7
 
 Released 2020-12-17

--- a/astronomer/airflow/version_check/plugin.py
+++ b/astronomer/airflow/version_check/plugin.py
@@ -7,7 +7,7 @@ from airflow.utils.db import create_session
 
 from .update_checks import UpdateAvailableBlueprint
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Version 1.0.8

Released 2022-01-24

- Use `add_view_no_menu since add_api` is removed in airflow (#24)
- Fix CI issues and Bump dev requirements (#26)
