### PR TITLE
Bump CI dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: circleci/python:3.7-buster
+      - image: cimg/python:3.7
     steps:
       - checkout
       - &restore_venv

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -289,8 +289,10 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
         with create_session() as session:
             engine = session.get_bind(mapper=None, clause=None)
             if not engine.has_table(AstronomerVersionCheck.__tablename__):
-                self.log.warn("AstronomerVersionCheck tables are missing (plugin not installed at upgradedb "
-                              "time?). No update checks will be performed")
+                self.log.warning(
+                    "AstronomerVersionCheck tables are missing (plugin not installed at upgradedb "
+                    "time?). No update checks will be performed"
+                )
                 return
 
         self.airflow_base_template = app.appbuilder.base_template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,2 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "pytest-runner~=4.0"]
-
+requires = ["setuptools>=60.5.0", "wheel", "pytest-runner~=5.3"]

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
         'importlib_metadata;python_version<"3.9"'
     ],
     setup_requires=[
-        'pytest-runner~=4.0',
+        'pytest-runner~=5.3',
     ],
     tests_require=[
         'astronomer-airflow-version-check[test]',


### PR DESCRIPTION
- Bumps docker image from ` circleci/python:3.7-buster` to `cimg/python:3.7` (https://circleci.com/developer/images/image/cimg/python)
- Replaces deprecated log.warn() with log.warning
- Bump setuptools in pyproject.toml