### PR TITLE
Manually pre-install wheel so cryptography gets installed from a wheel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,15 +80,19 @@ jobs:
           name: verify tag
           command: |-
             # Install necessary packages and verify that the tag is correct
+            # gcc package -> gcc (executable)
+            # g++ package -> cc1plus (executable)
+            # python3-dev package -> Python.h
+            # libffi-dev -> ffi.h
+            # musl-dev package -> limits.h
             apk update && apk add python3-dev \
-                                          gcc \
-                                          libc-dev \
-                                          libffi-dev \
-                                          musl-dev \
-                                          openssl-dev \
-                                          cargo
+                                  gcc \
+                                  g++ \
+                                  libffi-dev \
+                                  musl-dev
             python3 -m venv .venv
             . .venv/bin/activate
+            pip install --upgrade pip setuptools wheel
             pip install -r dev-requirements.txt
             python3 setup.py verify
       - attach_workspace:


### PR DESCRIPTION
Instead of installing a bunch of binary packages so pip can successfully install the cryptography C shims, this PR minimizes the number of installed packages, and pre-installs `wheel` into the virtualenv so that pip can use the wheel packages of cryptography.

I manually tested the `verify tag` commands on bare metal macOS as well as within a Docker container.

Using wheel packages is likely going make our build and deploy process slightly more resilient than installing binary packages and compiling cryptography each time (as the Docker image may get updated out from under us and binary package names may change around).