### PR TITLE
Show available updates in a better way

### DIFF
--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -250,15 +250,29 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
             AstronomerAvailableVersion.hidden_from_ui.is_(False)
         )
 
-        for rel in sorted(available_releases, key=lambda v: version.parse(v.version), reverse=True):
-            # For simplicity in the UI, only show the latest version that is available
+        ac_version = version.parse(get_ac_version())
+        base_version = ac_version.base_version
+
+        sorted_releases = sorted(available_releases, key=lambda v: version.parse(v.version), reverse=True)
+        for rel in sorted_releases:
+            if version.parse(rel.version) != ac_version and rel.version.startswith(base_version):
+                return {
+                    "level": rel.level,
+                    "date_released": rel.date_released,
+                    "description": rel.description,
+                    "version": rel.version,
+                    "url": rel.url,
+                }
+
+        if sorted_releases:
             return {
-                'level': rel.level,
-                'date_released': rel.date_released,
-                'description': rel.description,
-                'version': rel.version,
-                'url': rel.url,
+                'level': sorted_releases[0].level,
+                'date_released': sorted_releases[0].date_released,
+                'description': sorted_releases[0].description,
+                'version': sorted_releases[0].version,
+                'url': sorted_releases[0].url,
             }
+
         return None
 
     def new_template_vars(self):

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -255,7 +255,8 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
 
         sorted_releases = sorted(available_releases, key=lambda v: version.parse(v.version), reverse=True)
         for rel in sorted_releases:
-            if version.parse(rel.version) > ac_version and rel.base_version == base_version:
+            rel_parsed_version = version.parse(rel.version)
+            if rel_parsed_version > ac_version and rel_parsed_version.base_version == base_version:
                 return {
                     "level": rel.level,
                     "date_released": rel.date_released,

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -265,12 +265,13 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
                 }
 
         if sorted_releases:
+            recent_release = sorted_releases[0]
             return {
-                'level': sorted_releases[0].level,
-                'date_released': sorted_releases[0].date_released,
-                'description': sorted_releases[0].description,
-                'version': sorted_releases[0].version,
-                'url': sorted_releases[0].url,
+                'level': recent_release.level,
+                'date_released': recent_release.date_released,
+                'description': recent_release.description,
+                'version': recent_release.version,
+                'url': recent_release.url,
             }
 
         return None

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -255,7 +255,7 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
 
         sorted_releases = sorted(available_releases, key=lambda v: version.parse(v.version), reverse=True)
         for rel in sorted_releases:
-            if version.parse(rel.version) != ac_version and rel.version.startswith(base_version):
+            if version.parse(rel.version) > ac_version and rel.base_version == base_version:
                 return {
                     "level": rel.level,
                     "date_released": rel.date_released,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,3 +89,12 @@ class FlaskLoginClient(FlaskClient):
             with self.session_transaction() as sess:
                 sess["user_id"] = user.id
                 sess["_fresh"] = fresh
+
+
+@pytest.fixture
+def session():
+    from airflow.utils.session import create_session
+
+    with create_session() as session:
+        yield session
+        session.rollback()

--- a/tests/test_update_checks.py
+++ b/tests/test_update_checks.py
@@ -1,0 +1,85 @@
+from astronomer.airflow.version_check.models import AstronomerVersionCheck, AstronomerAvailableVersion
+from astronomer.airflow.version_check.update_checks import CheckThread, UpdateAvailableBlueprint
+from unittest import mock
+import pytest
+from packaging import version
+
+
+@pytest.mark.parametrize("image_version, lowest_tag", [("2.2.0.post2", "2.2.0"), ("2.2.3.post1", "2.2.3")])
+@mock.patch('astronomer.airflow.version_check.update_checks.get_ac_version')
+def test_update_check_for_image_with_newer_patch(mock_ac_version, image_version, lowest_tag, app, session):
+    from airflow.utils.db import resetdb
+
+    mock_ac_version.return_value = image_version
+    with app.app_context():
+        resetdb()
+        vc = AstronomerVersionCheck(singleton=True)
+        session.add(vc)
+        session.commit()
+
+        thread = CheckThread()
+        thread.ac_version = image_version
+        thread.check_for_update()
+        # Here we check for the highest patch on the selected image
+        # If the image is 2.2.0.post2, then the highest patch may be 2.2.0-5
+        latest_patch = (
+            session.query(AstronomerAvailableVersion)
+            .filter(AstronomerAvailableVersion.version.like(f"{lowest_tag}%"))
+            .order_by(AstronomerAvailableVersion.date_released.desc())
+            .first()
+        )
+        blueprint = UpdateAvailableBlueprint()
+        result = blueprint.available_update()
+        # UI displays the latest patch release
+        assert result['version'] == latest_patch.version
+
+
+@mock.patch('astronomer.airflow.version_check.update_checks.get_ac_version')
+def test_update_check_for_image_already_on_the_highest_patch(mock_ac_version, app, session):
+    from airflow.utils.db import resetdb
+
+    image_version = "2.0.0.post10"
+    mock_ac_version.return_value = image_version
+    with app.app_context():
+        resetdb()
+        vc = AstronomerVersionCheck(singleton=True)
+        session.add(vc)
+        session.commit()
+
+        thread = CheckThread()
+        # pretend we are on the image_version
+        thread.ac_version = image_version
+        thread.check_for_update()
+        available_releases = session.query(AstronomerAvailableVersion).filter(
+            AstronomerAvailableVersion.hidden_from_ui.is_(False)
+        )
+        # Get the latest release
+        highest_version = sorted(available_releases, key=lambda v: version.parse(v.version), reverse=True)
+        blueprint = UpdateAvailableBlueprint()
+        result = blueprint.available_update()
+        # UI displays the latest release
+        assert result['version'] == highest_version[0].version
+
+
+@mock.patch('astronomer.airflow.version_check.update_checks.get_ac_version')
+def test_update_check_dont_show_update_if_no_new_version_available(mock_ac_version, app, session):
+    from airflow.utils.db import resetdb
+
+    with app.app_context():
+        resetdb()
+        vc = AstronomerVersionCheck(singleton=True)
+        session.add(vc)
+        session.commit()
+        thread = CheckThread()
+        thread.ac_version = "2.0.0.post10"  # just to have a value, we update it later
+        # Find the highest version available
+        available_releases = thread._get_update_json()['available_releases'][-1]
+        public = version.parse(available_releases['version']).public
+        # Update the mock version to the highest available
+        mock_ac_version.return_value = public
+        thread.ac_version = public
+        thread.check_for_update()
+        blueprint = UpdateAvailableBlueprint()
+        result = blueprint.available_update()
+        # Nothing would be displayed if there is no new version available
+        assert result is None


### PR DESCRIPTION
This PR improves how we display available updates. If a user has image 2.2.1-2 and
there're releases 2.2.1-3 and 2.2.3-4, we want to show 2.2.1-3 to the user. Until the user
upgrades to 2.2.1-3 he cannot see 2.2.3-4.



closes https://github.com/astronomer/issues-airflow/issues/154