### PR TITLE
Version 1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 1.0.9
+
+- Show available updates in a better way (#34)
+- Add pre-commit (#35)
+- Repeat 'venv' creation in publish job (#32)
+- Fix setuptools not found during publish (#31)
+- Bump CI dependencies (#28)
+
 ## Version 1.0.8
 
 Released 2022-01-24

--- a/astronomer/airflow/version_check/plugin.py
+++ b/astronomer/airflow/version_check/plugin.py
@@ -7,7 +7,7 @@ from airflow.utils.db import create_session
 
 from .update_checks import UpdateAvailableBlueprint
 
-__version__ = "1.0.8"
+__version__ = "1.0.9"
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Version 1.0.9

- Show available updates in a better way (#34)
- Add pre-commit (#35)
- Repeat 'venv' creation in publish job (#32)
- Fix setuptools not found during publish (#31)
- Bump CI dependencies (#28)