### PR TITLE
Fix plugin to work with Airflow 2.3.3+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ wheels/
 # Testing
 /.venv/
 testdb.sqlite
+env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: pyupgrade
         args: ["--py36-plus"]
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.6.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -302,7 +302,7 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
 
             return self.response(200)
 
-    def register(self, app, options, first_registration):
+    def register(self, app, options):
         """
         Re-configure Flask to use our customized layout (that includes the call-home JS)
         Called by Flask when registering the blueprint to the app
@@ -333,7 +333,7 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
         app.appbuilder.add_view_no_menu(self.UpdateAvailable)
         self.app_context_processor(self.new_template_vars)
 
-        super().register(app, options, first_registration)
+        super().register(app, options)
 
 
 def get_ac_version():
@@ -367,7 +367,7 @@ def get_user_string_data():
         distro_infos = dict(
             filter(
                 lambda x: x[1],
-                zip(["name", "version", "id"], distro.linux_distribution()),
+                zip(["name", "version", "id"], (distro.name(), distro.version(), distro.id())),
             )
         )
         if distro_infos:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,13 +1,6 @@
 # Requirements that can't be expressed in setup.py
 wheel
 
-# We need our back-ported fixes to Airflow for our tests to pass
-# We need to specify the astro version here, otherwise it would install the one from pypi repo instead
---extra-index-url=https://pip.astronomer.io/simple/
---constraint=https://raw.githubusercontent.com/astronomer/ap-airflow/master/2.2.3/bullseye/build-time-pip-constraints.txt
-astronomer-certified==2.2.3.*
+apache-airflow==2.3.3rc1
 
 -e .[test]
-
-marshmallow-sqlalchemy~=0.26.1
-marshmallow~=3.14.0

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,6 @@ setup(
         ]
     },
     install_requires=[
-        'astronomer-certified>=1.10.7',
         'distro~=1.5',
         'lazy_object_proxy~=1.3',
         'packaging>=20.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-import os
-
 from flask.testing import FlaskClient
 import pytest
 
@@ -32,8 +30,6 @@ def client(app, user, request):
 
 @pytest.fixture(scope='module')
 def app():
-    os.environ['AIRFLOW__CORE__SQL_ALCHEMY_CONN'] = 'sqlite:///testdb.sqlite'
-    os.environ['AIRFLOW__WEBSERVER__RBAC'] = 'True'
     from airflow.utils.db import initdb
     from airflow.www.app import create_app
 


### PR DESCRIPTION
The register method of Blueprint changed in Flask 2+ which Airflow
2.3.3 is based on. This PR fixes the issue and also removed astronomer-certified
as dependency of this plugin.
Furthermore, a distro warning was also fixed