### PR TITLE
Remove create table hook on `upgradedb`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ wheels/
 # Testing
 /.venv/
 testdb.sqlite
-env
+env/

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -13,6 +13,7 @@ import lazy_object_proxy
 import pendulum
 import requests
 import sqlalchemy.exc
+from sqlalchemy import inspect
 from flask import Blueprint, current_app
 from flask_appbuilder.api import BaseApi, expose
 from flask_appbuilder.security.decorators import protect
@@ -314,7 +315,8 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
 
         with create_session() as session:
             engine = session.get_bind(mapper=None, clause=None)
-            if not engine.has_table(AstronomerVersionCheck.__tablename__):
+            inspector = inspect(engine)
+            if not inspector.has_table(AstronomerVersionCheck.__tablename__):
                 self.log.warning(
                     "AstronomerVersionCheck tables are missing (plugin not installed at upgradedb "
                     "time?). No update checks will be performed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=60.5.0", "wheel", "pytest-runner~=5.3"]
+requires = ["setuptools==63.4.3", "wheel", "pytest-runner~=5.3"]
 
 [tool.black]
 line-length = 110

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "login_as")
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def client(app, user, request):
     """The test client, optionally logged in as a user of the given role
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -11,10 +11,9 @@ def test_plugin_registered():
     assert plugins_manager.plugins[0].flask_blueprints != []
 
 
-@pytest.mark.xfail(condition=True, reason="Needs deeper investigation")
 @pytest.mark.login_as('Admin')
 def test_logged_in(client):
-    response = client.get(url_for('Airflow.index'))
+    response = client.get(url_for('Airflow.index'), follow_redirects=True)
     assert response.status_code == 200
     assert b"update-notice.css" in response.data, "Ensure our template customizations are shown"
 

--- a/tests/test_update_checks.py
+++ b/tests/test_update_checks.py
@@ -83,3 +83,23 @@ def test_update_check_dont_show_update_if_no_new_version_available(mock_ac_versi
         result = blueprint.available_update()
         # Nothing would be displayed if there is no new version available
         assert result is None
+
+
+def test_plugin_table_created(app, session):
+    from airflow.cli.commands.standalone_command import standalone
+    from sqlalchemy import inspect
+    import threading
+
+    engine = session.get_bind(mapper=None, clause=None)
+    inspector = inspect(engine)
+    with app.app_context():
+        thread = threading.Thread(target=standalone, args=('webserver',))
+        thread.daemon = True
+        thread.start()
+        while thread.isAlive():
+            if inspector.has_table('task_instance'):
+                break
+        for _ in range(10):
+            x = inspector.has_table('astro_version_check')
+        assert x
+        thread.join(timeout=1)


### PR DESCRIPTION
We currently depend on a before call hook on `upgradedb` to create tables
for the plugin. This PR replaces it with a query for existence of the plugin
tables and creates the table if needed.

Also, some deprecation warnings were fixed