### PR TITLE
Make version check plugin work in runtime

### DIFF
--- a/astronomer/airflow/version_check/templates/update-available.html
+++ b/astronomer/airflow/version_check/templates/update-available.html
@@ -4,7 +4,7 @@
     {% if "can_dismiss" | is_item_visible("UpdateAvailable") %}
       <button data-href="{{ url_for('UpdateAvailable.dismiss', version=cea_update_available.version) }}" title="Ignore this update, and hide this message from all users">&times; Ignore this update</button>
     {% endif %}
-    <p><strong>A new version of Astronomer Certified is available.</strong></p>
+    <p><strong>A new version of {{cea_update_available.app_name}} is available.</strong></p>
     <p>
     {% if cea_update_available.url %}
       <a href="{{ cea_update_available.url }}">

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -93,7 +93,7 @@ class CheckThread(threading.Thread, LoggingMixin):
             try:
                 update_available, wake_up_in = self.check_for_update()
                 if update_available == UpdateResult.SUCCESS_UPDATE_AVAIL:
-                    self.log.info("A new version of %s is available", _app_name(True))
+                    self.log.info("A new version of %s is available", _app_name(include_airflow=True))
                 self.log.info("Check finished, next check in %s seconds", wake_up_in)
             except Exception:
                 self.log.exception("Update check died with an exception, trying again in one hour")
@@ -140,7 +140,7 @@ class CheckThread(threading.Thread, LoggingMixin):
 
             self.log.info(
                 "Checking for new version of %s, previous check was performed at %s",
-                _app_name(True),
+                _app_name(include_airflow=True),
                 lock.last_checked,
             )
 

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -37,6 +37,12 @@ except ImportError:
 # "update_checks.py"
 
 
+def _app_name():
+    if os.environ.get("ASTRONOMER_RUNTIME_VERSION", None):
+        return "Astronomer Runtime"
+    return "Astronomer Certified"
+
+
 class UpdateResult(enum.Enum):
     FAILURE = enum.auto()
     NOT_DUE = enum.auto()
@@ -58,7 +64,10 @@ class CheckThread(threading.Thread, LoggingMixin):
         )
 
         if conf.getboolean('astronomer', '_fake_check', fallback=False):
-            self._get_update_json = self._make_fake_response
+            if "runtime" in _app_name().lower():
+                self._get_update_json = self._make_fake_runtime_response
+            else:
+                self._get_update_json = self._make_fake_response
 
     def run(self):
         """
@@ -81,7 +90,7 @@ class CheckThread(threading.Thread, LoggingMixin):
             try:
                 update_available, wake_up_in = self.check_for_update()
                 if update_available == UpdateResult.SUCCESS_UPDATE_AVAIL:
-                    self.log.info("A new version of Astronomer Certified Airflow is available")
+                    self.log.info("A new version of %s is available", _app_name())
                 self.log.info("Check finished, next check in %s seconds", wake_up_in)
             except Exception:
                 self.log.exception("Update check died with an exception, trying again in one hour")
@@ -127,7 +136,8 @@ class CheckThread(threading.Thread, LoggingMixin):
                 return UpdateResult.NOT_DUE, how_long
 
             self.log.info(
-                "Checking for new version of Astronomer Certified Airflow, previous check was performed at %s",
+                "Checking for new version of %s, previous check was performed at %s",
+                _app_name(),
                 lock.last_checked,
             )
 
@@ -152,6 +162,9 @@ class CheckThread(threading.Thread, LoggingMixin):
             return result, self.check_interval.total_seconds()
 
     def _process_update_json(self, update_document):
+        runtime = update_document.get("runtimeVersions", None)
+        if runtime:
+            return self._process_update_json_v1_0(update_document, runtime=True)
         version = update_document.get('version', None)
         if version != '1.0':
             r = repr(version) if version else '<MISSING>'
@@ -159,25 +172,30 @@ class CheckThread(threading.Thread, LoggingMixin):
 
         return self._process_update_json_v1_0(update_document)
 
-    def _process_update_json_v1_0(self, update_document):
+    def _process_update_json_v1_0(self, update_document, runtime=False):
         from .models import AstronomerAvailableVersion
+
+        versions = update_document.get("available_releases", [])
+        if runtime:
+            versions = self._convert_runtime_versions(update_document.get("runtimeVersions", {}))
 
         current_version = version.parse(self.ac_version)
 
         self.log.debug(
             "Raw versions in update document: %r",
-            list(r['version'] for r in update_document.get('available_releases', [])),
+            list(r['version'] for r in versions),
         )
 
         def parse_version(rel):
             rel['parsed_version'] = version.parse(rel['version'])
             return rel
 
-        releases = map(parse_version, update_document.get('available_releases', []))
+        releases = map(parse_version, versions)
 
         for release in sorted(releases, key=lambda rel: rel['parsed_version'], reverse=True):
             ver = version.parse(release['version'])
-
+            if release['channel'] in ['alpha', 'beta']:  # ignore alpha & beta releases
+                continue
             if ver <= current_version:
                 self.log.debug(
                     "Got to a release (%s) that is older than the running version (%s) -- stopping looking for more",
@@ -199,6 +217,20 @@ class CheckThread(threading.Thread, LoggingMixin):
                 description=release.get('description'),
             )
 
+    def _convert_runtime_versions(self, runtime_versions):
+        versions = []
+        for k, v in runtime_versions.items():
+            metadata = v['metadata']
+            new_dict = {}
+            new_dict['version'] = k
+            new_dict["level"] = ""
+            new_dict["url"] = ""
+            new_dict["description"] = ""
+            new_dict['release_date'] = metadata['releaseDate']
+            new_dict['channel'] = metadata['channel']
+            versions.append(new_dict)
+        return versions
+
     def _make_fake_response(self):
         v = version.parse(self.ac_version)
 
@@ -213,6 +245,25 @@ class CheckThread(threading.Thread, LoggingMixin):
                     'level': 'bug_fix',
                 },
             ],
+        }
+
+    def _make_fake_runtime_response(self):
+        v = version.parse(self.ac_version)
+
+        new_version = f'{v.major}.{v.minor}.{v.micro}'
+
+        return {
+            'features': {},
+            'runtimeVersions': {
+                new_version: {
+                    "metadata": {
+                        "airflowVersion": "2.1.1",
+                        "channel": "deprecated",
+                        "releaseDate": "2021-07-20",
+                    },
+                    "migrations": {"airflowDatabase": "true"},
+                },
+            },
         }
 
     def _get_update_json(self):  # pylint: disable=E0202
@@ -256,14 +307,24 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
 
         sorted_releases = sorted(available_releases, key=lambda v: version.parse(v.version), reverse=True)
         for rel in sorted_releases:
+            # Only notify about the latest release if the user is in the highest patch level.
+            # On runtime:
+            # if the user is on version 5.0.6 and 5.0.8, 6.0.0 are available,
+            # notify the user about 5.0.8 and don't notify user about 6.0.0.
             rel_parsed_version = version.parse(rel.version)
-            if rel_parsed_version > ac_version and rel_parsed_version.base_version == base_version:
+            rel_parsed_base_version = rel_parsed_version.base_version
+            if "runtime" in _app_name().lower():
+                rel_parsed_base_version = rel_parsed_version.major
+                base_version = ac_version.major
+
+            if rel_parsed_version > ac_version and rel_parsed_base_version == base_version:
                 return {
                     "level": rel.level,
                     "date_released": rel.date_released,
                     "description": rel.description,
                     "version": rel.version,
                     "url": rel.url,
+                    "app_name": _app_name(),
                 }
 
         if sorted_releases:
@@ -274,6 +335,7 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
                 'description': recent_release.description,
                 'version': recent_release.version,
                 'url': recent_release.url,
+                "app_name": _app_name(),
             }
 
         return None
@@ -339,6 +401,9 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
 
 
 def get_ac_version():
+    runtime_version = os.environ.get("ASTRONOMER_RUNTIME_VERSION", None)
+    if runtime_version:
+        return runtime_version
     try:
         import importlib_metadata
     except ImportError:

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -165,9 +165,8 @@ class CheckThread(threading.Thread, LoggingMixin):
             return result, self.check_interval.total_seconds()
 
     def _process_update_json(self, update_document):
-        runtime = update_document.get("runtimeVersions", None)
-        if runtime:
-            return self._process_update_json_v1_0(update_document, runtime=True)
+        if 'runtime' in _app_name().lower():
+            return self._process_update_json_v1_0(update_document)
         version = update_document.get('version', None)
         if version != '1.0':
             r = repr(version) if version else '<MISSING>'
@@ -175,11 +174,11 @@ class CheckThread(threading.Thread, LoggingMixin):
 
         return self._process_update_json_v1_0(update_document)
 
-    def _process_update_json_v1_0(self, update_document, runtime=False):
+    def _process_update_json_v1_0(self, update_document):
         from .models import AstronomerAvailableVersion
 
         versions = update_document.get("available_releases", [])
-        if runtime:
+        if 'runtime' in _app_name().lower():
             versions = self._convert_runtime_versions(update_document.get("runtimeVersions", {}))
 
         current_version = version.parse(self.ac_version)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def client(app, user, request):
         yield client
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def app():
     from airflow.utils.db import initdb
     from airflow.www.app import create_app

--- a/tests/test_runtime_update_checks.py
+++ b/tests/test_runtime_update_checks.py
@@ -1,0 +1,129 @@
+from astronomer.airflow.version_check.models import AstronomerVersionCheck, AstronomerAvailableVersion
+from astronomer.airflow.version_check.update_checks import CheckThread, UpdateAvailableBlueprint
+from unittest import mock
+import pytest
+from packaging import version
+
+
+@pytest.fixture(autouse=True)
+def mock_test_env(monkeypatch):
+    monkeypatch.setenv('AIRFLOW__ASTRONOMER__UPDATE_URL', "https://updates.astronomer.io/astronomer-runtime")
+
+
+@pytest.mark.parametrize("image_version, new_patch_version", [("4.0.0", "4.2.6")])
+def test_update_check_for_image_with_newer_patch(image_version, new_patch_version, app, session):
+    from airflow.utils.db import resetdb
+
+    with app.app_context(), mock.patch.dict("os.environ", {"ASTRONOMER_RUNTIME_VERSION": image_version}):
+        resetdb()
+        vc = AstronomerVersionCheck(singleton=True)
+        session.add(vc)
+        session.commit()
+
+        thread = CheckThread()
+        thread.ac_version = image_version
+        thread.check_for_update()
+        # Here we check for the highest patch on the selected image
+        # If the image is 4.0.0, then the highest patch may be 4.2.6 not 5+
+        latest_patch = (
+            session.query(AstronomerAvailableVersion)
+            .filter(AstronomerAvailableVersion.version.like(f"{new_patch_version}%"))
+            .order_by(AstronomerAvailableVersion.date_released.desc())
+            .first()
+        )
+        blueprint = UpdateAvailableBlueprint()
+        result = blueprint.available_update()
+        # UI displays the latest patch release
+        assert result['version'] == latest_patch.version
+
+
+def test_update_check_for_image_already_on_the_highest_patch(app, session):
+    from airflow.utils.db import resetdb
+
+    image_version = "5.0.0"
+    with app.app_context(), mock.patch.dict("os.environ", {"ASTRONOMER_RUNTIME_VERSION": image_version}):
+        resetdb()
+        vc = AstronomerVersionCheck(singleton=True)
+        session.add(vc)
+        session.commit()
+
+        thread = CheckThread()
+        # pretend we are on the image_version
+        thread.ac_version = image_version
+        thread.check_for_update()
+        available_releases = session.query(AstronomerAvailableVersion).filter(
+            AstronomerAvailableVersion.hidden_from_ui.is_(False)
+        )
+        # Get the latest release
+        highest_version = sorted(available_releases, key=lambda v: version.parse(v.version), reverse=True)
+        blueprint = UpdateAvailableBlueprint()
+        result = blueprint.available_update()
+        # UI displays the latest release
+        assert result['version'] == highest_version[0].version
+
+
+@mock.patch('astronomer.airflow.version_check.update_checks.get_ac_version')
+def test_update_check_dont_show_update_if_no_new_version_available(mock_ac_version, app, session):
+    from airflow.utils.db import resetdb
+
+    with app.app_context(), mock.patch.dict("os.environ", {"ASTRONOMER_RUNTIME_VERSION": '5.0.0'}):
+        resetdb()
+        vc = AstronomerVersionCheck(singleton=True)
+        session.add(vc)
+        session.commit()
+        thread = CheckThread()
+        thread.ac_version = '5.0.0'
+        available_releases = thread._get_update_json()['runtimeVersions']
+
+        latest_version = list(available_releases)[-1]
+        public = version.parse(latest_version).public
+        # Update the mock version to the highest available
+        mock_ac_version.return_value = public
+        thread.ac_version = public
+        thread.check_for_update()
+        blueprint = UpdateAvailableBlueprint()
+        result = blueprint.available_update()
+        # Nothing would be displayed if there is no new version available
+        assert result is None
+
+
+def test_alpha_beta_versions_are_not_recorded(app, session):
+    from airflow.utils.db import resetdb
+
+    with app.app_context(), mock.patch.dict("os.environ", {"ASTRONOMER_RUNTIME_VERSION": '4.0.0'}):
+        resetdb()
+        vc = AstronomerVersionCheck(singleton=True)
+        session.add(vc)
+        session.commit()
+
+        thread = CheckThread()
+        thread.ac_version = '4.0.0'
+        available_releases = thread._get_update_json()['runtimeVersions']
+        alpha_beta = [
+            k for k, v in available_releases.items() if v['metadata']['channel'] in ['alpha', 'beta']
+        ]
+        thread.check_for_update()
+        recorded = session.query(AstronomerAvailableVersion).all()
+        recorded = [r.version for r in recorded]
+        for item in alpha_beta:
+            assert item not in recorded
+
+
+def test_plugin_table_created(app, session):
+    from airflow.cli.commands.standalone_command import standalone
+    from sqlalchemy import inspect
+    import threading
+
+    engine = session.get_bind(mapper=None, clause=None)
+    inspector = inspect(engine)
+    with app.app_context(), mock.patch.dict("os.environ", {"ASTRONOMER_RUNTIME_VERSION": '5.0.0'}):
+        thread = threading.Thread(target=standalone, args=('webserver',))
+        thread.daemon = True
+        thread.start()
+        while thread.isAlive():
+            if inspector.has_table('task_instance'):
+                break
+        for _ in range(10):
+            x = inspector.has_table('astro_version_check')
+        assert x
+        thread.join(timeout=1)


### PR DESCRIPTION
This PR adapts this plugin to work in astronomer runtime.

Leveraging the ASTRONOMER_RUNTIME_VERSION environment variable, we can
tell if we are on runtime or not and apply the logic accordingly