### PR TITLE
Release v1.0.11

### DIFF
--- a/astronomer/airflow/version_check/plugin.py
+++ b/astronomer/airflow/version_check/plugin.py
@@ -8,7 +8,7 @@ from sqlalchemy import inspect
 
 from .update_checks import UpdateAvailableBlueprint
 
-__version__ = "1.0.10"
+__version__ = "1.0.11"
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
This contains fixes to make the version check plugin work in 2.4.0 as well as in runtime