### PR TITLE
Update the base template options

### DIFF
--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -419,7 +419,7 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
 
         self.airflow_base_template = app.appbuilder.base_template
 
-        if app.appbuilder.base_template in ["airflow/master.html", "airflow/main.html"]:
+        if app.appbuilder.base_template in ["airflow/master.html", "airflow/main.html", "runtime_base.html"]:
             app.appbuilder.base_template = "astro-baselayout.html"
         else:
             self.log.warning(


### PR DESCRIPTION
Since runtime 6.1.0, the update available notice was not shown. What I was able to find was that the base template comes as runtime_base.html, updating it here made it to work