### PR TITLE
Properly set the version column type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.9
     steps:
       - checkout
       - run:

--- a/astronomer/airflow/version_check/models.py
+++ b/astronomer/airflow/version_check/models.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import sqlalchemy.ext
 from airflow.models import Base
-from airflow.utils.db import create_session, provide_session
+from airflow.utils.db import create_session
 from airflow.utils.net import get_hostname
 from airflow.utils.timezone import utcnow
 from airflow.utils.sqlalchemy import UtcDateTime
@@ -80,22 +80,9 @@ class AstronomerVersionCheck(Base):
         return f"{get_hostname()}-{os.getpid()}#{threading.get_ident()}"
 
 
-@provide_session
-def _get_version_column_type(session):
-    """
-    To avoid MySQL/MariaDB errors when using TEXT with Primary Key
-    Details: https://stackoverflow.com/questions/1827063/mysql-error-key-specification-without-a-key-length
-    """
-    if session.bind.dialect.name == "mysql":
-        col_type = String(255)
-    else:
-        col_type = Text
-    return col_type
-
-
 class AstronomerAvailableVersion(Base):
     __tablename__ = "astro_available_version"
-    version = Column(_get_version_column_type(), nullable=False, primary_key=True)
+    version = Column(Text().with_variant(String(255), "mysql"), nullable=False, primary_key=True)
     level = Column(Text, nullable=False)
     date_released = Column(UtcDateTime(timezone=True), nullable=False)
     description = Column(Text)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,5 +2,6 @@
 wheel
 
 apache-airflow==2.7.1 --constraint="https://raw.githubusercontent.com/apache/airflow/constraints-2.7.1/constraints-3.9.txt"
+flake8==4.0.0
 
 -e .[test]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 # Requirements that can't be expressed in setup.py
 wheel
 
-apache-airflow==2.6.1
+apache-airflow==2.7.1 --constraint="https://raw.githubusercontent.com/apache/airflow/constraints-2.7.1/constraints-3.9.txt"
 
 -e .[test]

--- a/tests/test_runtime_update_checks.py
+++ b/tests/test_runtime_update_checks.py
@@ -120,7 +120,7 @@ def test_plugin_table_created(app, session):
         thread = threading.Thread(target=standalone, args=('webserver',))
         thread.daemon = True
         thread.start()
-        while thread.isAlive():
+        while thread.is_alive():
             if inspector.has_table('task_instance'):
                 break
         for _ in range(10):


### PR DESCRIPTION
This was using session to check dialect and thus interferring with scheduler session
 but sqlalchemy has with_variant method for doing the same thing