### PR TITLE
Add Warning for Yanked Runtime Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ message in the Airflow UI.
 Additionally, this plugin provides warnings in the Airflow UI for the following scenarios:
 - When the current version will reach its end of life (EOL) in 30 days (default, configurable).
 - When the current version has already reached its end of life (EOL).
+- When the current version has been yanked.
 
 This plugin also shows options to dismiss the EOL warnings for a configurable number of days (default is 7 days). There is also an option to completely disable the EOL warning.
+
+Additionally, it checks if the current running version of Astronomer Runtime has been yanked. If a yanked version is detected, a warning message will appear in the Airflow UI. Removed versions will not be displayed as available updates to prevent users from being prompted to upgrade to a yanked version.
 
 ## Settings
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Additionally, this plugin provides warnings in the Airflow UI for the following 
 
 This plugin also shows options to dismiss the EOL warnings for a configurable number of days (default is 7 days). There is also an option to completely disable the EOL warning.
 
-Additionally, it checks if the current running version of Astronomer Runtime has been yanked. If a yanked version is detected, a warning message will appear in the Airflow UI. Removed versions will not be displayed as available updates to prevent users from being prompted to upgrade to a yanked version.
+Additionally, it checks if the current running version of Astronomer Runtime has been yanked. If a yanked version is detected, a warning message will appear in the Airflow UI. The yanked versions will not be displayed as available updates to prevent users from being prompted to upgrade to a yanked version.
 
 ## Settings
 

--- a/astronomer/airflow/version_check/models.py
+++ b/astronomer/airflow/version_check/models.py
@@ -99,5 +99,6 @@ class AstronomerAvailableVersion(Base):
     hidden_from_ui = Column(Boolean, default=False, nullable=False)
     end_of_support = Column(UtcDateTime(timezone=True), nullable=True)
     eos_dismissed_until = Column(UtcDateTime(timezone=True), nullable=True)
+    yanked = Column(Boolean, default=False, nullable=False)
 
     __table_args__ = (Index('idx_astro_available_version_hidden', hidden_from_ui),)

--- a/astronomer/airflow/version_check/models.py
+++ b/astronomer/airflow/version_check/models.py
@@ -99,6 +99,6 @@ class AstronomerAvailableVersion(Base):
     hidden_from_ui = Column(Boolean, default=False, nullable=False)
     end_of_support = Column(UtcDateTime(timezone=True), nullable=True)
     eos_dismissed_until = Column(UtcDateTime(timezone=True), nullable=True)
-    yanked = Column(Boolean, default=False, nullable=False)
+    yanked = Column(Boolean, default=False, nullable=True)
 
     __table_args__ = (Index('idx_astro_available_version_hidden', hidden_from_ui),)

--- a/astronomer/airflow/version_check/plugin.py
+++ b/astronomer/airflow/version_check/plugin.py
@@ -99,7 +99,7 @@ class AstronomerVersionCheckPlugin(AirflowPlugin):
             AstronomerAvailableVersion.__tablename__: [
                 Column('end_of_support', UtcDateTime(timezone=True), nullable=True),
                 Column('eos_dismissed_until', UtcDateTime(timezone=True), nullable=True),
-                Column('yanked', Boolean, nullable=False, default=False),
+                Column('yanked', Boolean, nullable=True, default=False),
             ],
         }
 

--- a/astronomer/airflow/version_check/plugin.py
+++ b/astronomer/airflow/version_check/plugin.py
@@ -4,7 +4,7 @@ import logging
 from airflow.configuration import conf
 from airflow.plugins_manager import AirflowPlugin
 from airflow.utils.db import create_session
-from sqlalchemy import inspect, Column
+from sqlalchemy import inspect, Column, Boolean
 from sqlalchemy.exc import SQLAlchemyError
 from airflow.utils.sqlalchemy import UtcDateTime
 from alembic.migration import MigrationContext
@@ -99,6 +99,7 @@ class AstronomerVersionCheckPlugin(AirflowPlugin):
             AstronomerAvailableVersion.__tablename__: [
                 Column('end_of_support', UtcDateTime(timezone=True), nullable=True),
                 Column('eos_dismissed_until', UtcDateTime(timezone=True), nullable=True),
+                Column('yanked', Boolean, nullable=False, default=False),
             ],
         }
 

--- a/astronomer/airflow/version_check/templates/update-available.html
+++ b/astronomer/airflow/version_check/templates/update-available.html
@@ -27,6 +27,12 @@
     </div>
   {% endif %}
 
+    {% if cea_update_available and cea_update_available.yanked %}
+    <div class="alert alert-warning ac-update-notice">
+      <p><strong>Warning: The current version {{ cea_update_available.version }} of {{ cea_update_available.app_name }} has been yanked.</strong></p>
+    </div>
+  {% endif %}
+
   {% if cea_eol_notice %}
     {% set eol_level = "error" if cea_eol_notice.level == "critical" else "warning" %}
     <div class="alert alert-{{ eol_level }} ac-update-notice">

--- a/astronomer/airflow/version_check/templates/update-available.html
+++ b/astronomer/airflow/version_check/templates/update-available.html
@@ -29,7 +29,7 @@
 
   {% if cea_yanked_warning %}
     <div class="alert alert-warning ac-update-notice">
-      <p><strong>{{ cea_yanked_warning | safe }}</strong></p>
+      <p><strong>{{ cea_yanked_warning }}</strong></p>
     </div>
   {% endif %}
 

--- a/astronomer/airflow/version_check/templates/update-available.html
+++ b/astronomer/airflow/version_check/templates/update-available.html
@@ -27,9 +27,9 @@
     </div>
   {% endif %}
 
-    {% if cea_update_available and cea_update_available.yanked %}
+  {% if cea_yanked_warning %}
     <div class="alert alert-warning ac-update-notice">
-      <p><strong>Warning: The current version {{ cea_update_available.version }} of {{ cea_update_available.app_name }} has been yanked.</strong></p>
+      <p><strong>{{ cea_yanked_warning.description }}</strong></p>
     </div>
   {% endif %}
 

--- a/astronomer/airflow/version_check/templates/update-available.html
+++ b/astronomer/airflow/version_check/templates/update-available.html
@@ -29,7 +29,7 @@
 
   {% if cea_yanked_warning %}
     <div class="alert alert-warning ac-update-notice">
-      <p><strong>{{ cea_yanked_warning.description }}</strong></p>
+      <p><strong>{{ cea_yanked_warning | safe }}</strong></p>
     </div>
   {% endif %}
 

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -259,6 +259,7 @@ class CheckThread(threading.Thread, LoggingMixin):
                     description=release.get('description'),
                     end_of_support=end_of_support,
                     hidden_from_ui=True,
+                    yanked=release.get('yanked', False),
                 )
             else:
                 yield AstronomerAvailableVersion(
@@ -268,6 +269,7 @@ class CheckThread(threading.Thread, LoggingMixin):
                     url=release.get('url'),
                     description=release.get('description'),
                     end_of_support=end_of_support,
+                    yanked=release.get('yanked', False),
                 )
 
     def _convert_runtime_versions(self, runtime_versions):
@@ -295,6 +297,7 @@ class CheckThread(threading.Thread, LoggingMixin):
                 "description": "",
                 "release_date": "2021-07-20",
                 "end_of_support": "2022-02-28",
+                "yanked": False
             }]
         """
         versions = []
@@ -308,6 +311,7 @@ class CheckThread(threading.Thread, LoggingMixin):
             new_dict['release_date'] = metadata['releaseDate']
             new_dict['channel'] = metadata['channel']
             new_dict['end_of_support'] = metadata.get('endOfSupport')
+            new_dict['yanked'] = metadata.get('yanked', False)
             versions.append(new_dict)
         return versions
 
@@ -325,6 +329,7 @@ class CheckThread(threading.Thread, LoggingMixin):
                         "channel": "deprecated",
                         "releaseDate": "2021-07-20",
                         "endOfSupport": "2022-02-28",
+                        "yanked": False,
                     },
                     "migrations": {"airflowDatabase": "true"},
                 },
@@ -425,6 +430,7 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
                     "version": rel.version,
                     "url": rel.url,
                     "app_name": "Astronomer Runtime",
+                    "yanked": rel.yanked,
                 }
 
         if sorted_releases:
@@ -436,6 +442,7 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
                 'version': recent_release.version,
                 'url': recent_release.url,
                 "app_name": "Astronomer Runtime",
+                "yanked": recent_release.yanked,
             }
 
         return None

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -470,16 +470,19 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
         runtime_version = version.parse(get_runtime_version())
         current_version = (
             session.query(AstronomerAvailableVersion)
-            .filter(AstronomerAvailableVersion.version == str(runtime_version))
+            .filter(
+                AstronomerAvailableVersion.version == str(runtime_version),
+                AstronomerAvailableVersion.yanked.is_(True),
+            )
             .one_or_none()
         )
 
         if current_version and current_version.yanked:
             return (
-                "Warning: This version of Astronomer Runtime, {} has been yanked. "
+                f"Warning: This version of Astronomer Runtime, {runtime_version}, has been yanked. "
                 "Please refer to the "
                 "<a href='https://www.astronomer.io/docs/astro/runtime-version-lifecycle-policy#restricted-runtime-versions' "
-                "target='_blank'>documentation</a> for more details.".format(current_version.version)
+                "target='_blank'>documentation</a> for more details."
             )
 
         return None

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -480,9 +480,7 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
         if current_version and current_version.yanked:
             return (
                 f"Warning: This version of Astronomer Runtime, {runtime_version}, has been yanked. "
-                "Please refer to the "
-                "<a href='https://www.astronomer.io/docs/astro/runtime-version-lifecycle-policy#restricted-runtime-versions' "
-                "target='_blank'>documentation</a> for more details."
+                "We strongly recommend upgrading to a more recent supported version."
             )
 
         return None

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,6 @@
 -c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.1/constraints-3.9.txt
 wheel
 apache-airflow==2.7.1
-flake8==4.0.0
+flake8==5.0.4
 
 -e .[test]

--- a/tests/test_runtime_update_checks.py
+++ b/tests/test_runtime_update_checks.py
@@ -231,7 +231,6 @@ def test_available_yanked(app, session, image_version, yanked):
 
         if yanked:
             assert result is not None
-            assert result['version'] == image_version
-            assert "yanked" in result['description']
+            assert image_version in result
         else:
             assert result is None


### PR DESCRIPTION
This PR adds functionality to display a warning in the Airflow UI when the current runtime version has been yanked. This also adds a `yanked` column to the `AstronomerAvailableVersion` model to store the yanked status. When looking for possible upgrades, if it's yanked, we don't show it to the user. For example, if the user is on version 10.6 and version 10.7 has been yanked, we do not show 10.7 as an available upgrade.

I have tested the change by manually changing the version as yanked in the database:

<img width="1716" alt="Screenshot 2024-08-08 at 2 33 15 PM" src="https://github.com/user-attachments/assets/1ff00e70-d856-4a26-b691-c1dac838d306">


I have tested it on the following Astro deployment

### Dependencies

This pull request depends on the following pull request being merged first:
- [PR #72](https://github.com/astronomer/astronomer-airflow-version-check/pull/72)

closes: #68 