### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-case-conflict
       - id: check-executables-have-shebangs
@@ -22,12 +22,12 @@ repos:
       - id: remove-unicode-zero-width-non-breaking-spaces
       - id: remove-unicode-zero-width-space
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+    rev: v3.19.0
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.6.0
     hooks:
       - id: check-case-conflict
       - id: check-executables-have-shebangs
@@ -10,27 +10,27 @@ repos:
       - id: mixed-line-ending
         args: ["--fix=lf"]
       - id: trailing-whitespace
-  - repo: https://github.com/detailyang/pre-commit-shell
-    rev: 1.0.5
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
     hooks:
-      - id: shell-lint
+      - id: shellcheck
   - repo: https://github.com/astronomer/pre-commit-hooks
-    rev: bd325c947efcba13c03b4f4c93d882f2f83ed6ff
+    rev: 8b2d969bd549cd7c9454cc8bb54eec5b35c2e5e6
     hooks:
-      - id: remove-en-dashes
-      - id: remove-unicode-non-breaking-spaces
+      - id: replace-en-dashes
+      - id: replace-unicode-non-breaking-spaces
       - id: remove-unicode-zero-width-non-breaking-spaces
       - id: remove-unicode-zero-width-space
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.4
+    rev: v3.17.0
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: ["--py38-plus"]
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 24.8.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 7.1.1
     hooks:
-    -   id: flake8
+      - id: flake8

--- a/astronomer/airflow/version_check/models.py
+++ b/astronomer/airflow/version_check/models.py
@@ -1,8 +1,9 @@
-import datetime
+from __future__ import annotations
+
 import os
 import logging
 import threading
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import sqlalchemy.ext
 from airflow.models import Base
@@ -11,6 +12,11 @@ from airflow.utils.net import get_hostname
 from airflow.utils.timezone import utcnow
 from airflow.utils.sqlalchemy import UtcDateTime
 from sqlalchemy import Boolean, Column, Index, String, Text, or_
+
+if TYPE_CHECKING:
+    from datetime import timedelta
+    from sqlalchemy.orm import Session
+
 
 log = logging.getLogger(__name__)
 
@@ -41,8 +47,7 @@ class AstronomerVersionCheck(Base):
                 session.rollback()
 
     @classmethod
-    def acquire_lock(cls, check_interval, session):
-        # type: (datetime.timedelta, sqlalchemy.Session) -> Optional[AstronomerVersionCheck]
+    def acquire_lock(cls, check_interval: timedelta, session: Session) -> AstronomerVersionCheck | None:
         """
         Acquire an exclusive lock to perform an update check if the check is due
         and if another check is not already in progress.
@@ -101,4 +106,4 @@ class AstronomerAvailableVersion(Base):
     eos_dismissed_until = Column(UtcDateTime(timezone=True), nullable=True)
     yanked = Column(Boolean, default=False, nullable=True)
 
-    __table_args__ = (Index('idx_astro_available_version_hidden', hidden_from_ui),)
+    __table_args__ = (Index("idx_astro_available_version_hidden", hidden_from_ui),)

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -386,9 +386,11 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
                     description = "{} version {} {}.".format(
                         "Astronomer Runtime",
                         current_version.version,
-                        "has reached its end of life"
-                        if days_to_eol <= 0
-                        else "will reach its end of life in %d days" % days_to_eol,
+                        (
+                            "has reached its end of life"
+                            if days_to_eol <= 0
+                            else "will reach its end of life in %d days" % days_to_eol
+                        ),
                     )
                     return {
                         "level": eol_level,


### PR DESCRIPTION
This updates the hooks, but also:

- switches to the hook from the official shellcheck repo
- bumps the min python version to 3.8 for pyupgrade