### PR TITLE
Fix version check plugin for the new version scheme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
 
             python3 -m venv .venv
             . .venv/bin/activate
-            pip install --upgrade pip setuptools wheel
+            pip install --upgrade pip setuptools wheel==0.45.1
             pip install -r dev-requirements.txt
             python3 setup.py verify
       - attach_workspace:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.0.5
+- Fix version check plugin compatible for the new version scheme (#78)
+
 ## Version 2.0.4
 - Update README.md to replace AC reference with runtime reference (#64)
 - Add warnings around current versions EOL date (#72)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## Version 2.0.5
-- Fix version check plugin compatible for the new version scheme (#78)
-
 ## Version 2.0.4
 - Update README.md to replace AC reference with runtime reference (#64)
 - Add warnings around current versions EOL date (#72)

--- a/astronomer/airflow/version_check/models.py
+++ b/astronomer/airflow/version_check/models.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import sqlalchemy.ext
 from airflow.models import Base
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from airflow.utils.net import get_hostname
 from airflow.utils.timezone import utcnow
 from airflow.utils.sqlalchemy import UtcDateTime

--- a/astronomer/airflow/version_check/models.py
+++ b/astronomer/airflow/version_check/models.py
@@ -25,7 +25,7 @@ class AstronomerVersionCheck(Base):
     __tablename__ = "astro_version_check"
     singleton = Column(Boolean, default=True, nullable=False, primary_key=True)
 
-    # For infomration only
+    # For information only
     last_checked = Column(UtcDateTime(timezone=True))
     last_checked_by = Column(Text)
 

--- a/astronomer/airflow/version_check/plugin.py
+++ b/astronomer/airflow/version_check/plugin.py
@@ -12,7 +12,7 @@ from alembic.operations import Operations
 
 from .update_checks import UpdateAvailableBlueprint
 
-__version__ = "2.0.5"
+__version__ = "2.0.4"
 
 log = logging.getLogger(__name__)
 

--- a/astronomer/airflow/version_check/plugin.py
+++ b/astronomer/airflow/version_check/plugin.py
@@ -3,7 +3,7 @@ import logging
 
 from airflow.configuration import conf
 from airflow.plugins_manager import AirflowPlugin
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from sqlalchemy import inspect, Column, Boolean
 from sqlalchemy.exc import SQLAlchemyError
 from airflow.utils.sqlalchemy import UtcDateTime
@@ -12,7 +12,7 @@ from alembic.operations import Operations
 
 from .update_checks import UpdateAvailableBlueprint
 
-__version__ = "2.0.4"
+__version__ = "2.0.5"
 
 log = logging.getLogger(__name__)
 

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -92,18 +92,12 @@ def has_access_(permissions: Sequence[tuple[str, str]]) -> Callable[[T], T]:
 
 def parse_new_version(version_str):
     """
-    Parse versions like '3.0-1-nightly20241216' and '2.0.1'.
+    Parse versions like '3.0-1-nightly20241216'.
     """
-    try:
-        parsed_version = version.parse(version_str)
-    except ValueError:
-
-        # Extract major, minor, patch and metadata from version
-        match = re.match(r"(\d+)\.(\d+)(?:-(\d+))?", version_str)
-        major, minor, patch = match.groups()
-        parsed_version = version.parse(f"{major}.{minor}.{patch}")
-
-    return parsed_version
+    # Extract major, minor, patch and metadata from version
+    match = re.match(r"(\d+)\.(\d+)(?:-(\d+))?", version_str)
+    major, minor, patch = match.groups()
+    return version.parse(f"{major}.{minor}.{patch}")
 
 
 # This code is introduced to maintain backward compatibility, since with airflow > 2.8

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -320,14 +320,14 @@ class CheckThread(threading.Thread, LoggingMixin):
     def _make_fake_runtime_response(self):
         v = parse_new_version(self.runtime_version)
 
-        new_version = f'{v.major}.{v.minor}.{v.patch}'
+        new_version = f'{v.major}.{v.minor}-{v.patch}'
 
         return {
             'features': {},
-            'runtimeVersions': {
+            'runtimeVersionsV3': {
                 new_version: {
                     "metadata": {
-                        "airflowVersion": "2.1.1",
+                        "airflowVersion": "3.0.0",
                         "channel": "deprecated",
                         "releaseDate": "2021-07-20",
                         "endOfSupport": "2022-02-28",
@@ -458,7 +458,7 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
             return None
 
         session = get_state(app=current_app).db.session
-        runtime_version = parse_new_version(get_runtime_version())
+        runtime_version = get_runtime_version()
         current_version = (
             session.query(AstronomerAvailableVersion)
             .filter(AstronomerAvailableVersion.version == str(runtime_version))
@@ -471,7 +471,7 @@ class UpdateAvailableBlueprint(Blueprint, LoggingMixin):
         from .models import AstronomerAvailableVersion
 
         session = get_state(app=current_app).db.session
-        runtime_version = parse_new_version(get_runtime_version())
+        runtime_version = get_runtime_version()
         current_version = (
             session.query(AstronomerAvailableVersion)
             .filter(

--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -31,9 +31,9 @@ from airflow.utils.timezone import utcnow
 from functools import wraps
 
 try:
-    from airflow.www_rbac.decorators import action_logging
-except ImportError:
     from airflow.api_fastapi.logging.decorators import action_logging
+except ImportError:
+    from airflow.www.decorators import action_logging
 
 
 T = TypeVar("T", bound=Callable)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 # Requirements that can't be expressed in setup.py
 -c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.1/constraints-3.9.txt
-wheel
+wheel==0.45.1
 apache-airflow==2.7.1
 flake8==5.0.4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==63.4.3", "wheel", "pytest-runner~=5.3"]
+requires = ["setuptools==63.4.3", "wheel==0.45.1", "pytest-runner~=5.3"]
 
 [tool.black]
 line-length = 110

--- a/tests/test_runtime_update_checks.py
+++ b/tests/test_runtime_update_checks.py
@@ -2,7 +2,7 @@ from astronomer.airflow.version_check.models import AstronomerVersionCheck, Astr
 from astronomer.airflow.version_check.update_checks import CheckThread, UpdateAvailableBlueprint
 from unittest import mock
 import pytest
-from packaging.version import Version as version
+from packaging import version
 from datetime import timedelta
 from airflow.utils.timezone import utcnow
 
@@ -75,7 +75,7 @@ def test_update_check_dont_show_update_if_no_new_version_available(mock_runtime_
         session.commit()
         thread = CheckThread()
         thread.runtime_version = '4.0-1'
-        available_releases = thread._get_update_json()['runtimeVersions']
+        available_releases = thread._get_update_json()['runtimeVersionsV3']
 
         latest_version = list(available_releases)[-1]
         public = str(version.parse(latest_version))
@@ -133,7 +133,7 @@ def test_plugin_table_created(app, session):
 
 @pytest.mark.parametrize(
     "image_version, eol_days_offset, expected_level, expected_days_to_eol",
-    [("4.0.0", 10, 'warning', 10), ("4.0.0", -1, 'critical', -1)],
+    [("4.0-0", 10, 'warning', 10), ("4.0-0", -1, 'critical', -1)],
 )
 def test_days_to_eol_warning_and_critical(
     app, session, image_version, eol_days_offset, expected_level, expected_days_to_eol
@@ -168,7 +168,7 @@ def test_days_to_eol_warning_and_critical(
 
 @pytest.mark.parametrize(
     "image_version, yanked",
-    [("4.0.0", True), ("4.0.0", False)],
+    [("4.0-0", True), ("4.0-0", False)],
 )
 def test_yanked_version_excluded_from_updates(app, session, image_version, yanked):
     from airflow.utils.db import resetdb
@@ -203,7 +203,7 @@ def test_yanked_version_excluded_from_updates(app, session, image_version, yanke
 
 @pytest.mark.parametrize(
     "image_version, yanked",
-    [("4.0.0", True), ("4.0.0", False)],
+    [("4.0-0", True), ("4.0-0", False)],
 )
 def test_available_yanked(app, session, image_version, yanked):
     from airflow.utils.db import resetdb

--- a/tests/test_runtime_update_checks.py
+++ b/tests/test_runtime_update_checks.py
@@ -2,7 +2,7 @@ from astronomer.airflow.version_check.models import AstronomerVersionCheck, Astr
 from astronomer.airflow.version_check.update_checks import CheckThread, UpdateAvailableBlueprint
 from unittest import mock
 import pytest
-from semver import Version as version
+from packaging.version import Version as version
 from datetime import timedelta
 from airflow.utils.timezone import utcnow
 

--- a/tests/test_runtime_update_checks.py
+++ b/tests/test_runtime_update_checks.py
@@ -105,7 +105,7 @@ def test_update_check_for_image_already_on_the_highest_patch(mock_convert_runtim
         },
     ]
 
-    image_version = "3.0-2"  # highest patch of 3.0-2(using image that's no longer released)
+    image_version = "3.0-2"
     with app.app_context(), mock.patch.dict("os.environ", {"ASTRONOMER_RUNTIME_VERSION": image_version}):
         resetdb()
         vc = AstronomerVersionCheck(singleton=True)


### PR DESCRIPTION
Make the version check plugin compatible with the new RT version scheme, 
example 2.9-4-python-3.9 / 3.0-1-nightly20241216

Closes: https://github.com/astronomer/astro-runtime/issues/2020
Slack discussion: https://astronomer.slack.com/archives/C01UJJEN0P3/p1740998091410679