### PR TITLE
Releasing 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## Version 3.0.0rc3
-- Use new versioning scheme for checking of runtime images
+## Version 3.0.0
+- Use new versioning scheme for checking of runtime images (#78)
+- Move Version Check UI to runtime Middleware (#81)
+- Remove FAB dependency (#82)
 
 ## Version 2.0.4
 - Update README.md to replace AC reference with runtime reference (#64)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 3.0.0rc1
+- Use new versioning scheme for checking of runtime images
+
 ## Version 2.0.4
 - Update README.md to replace AC reference with runtime reference (#64)
 - Add warnings around current versions EOL date (#72)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 3.0.0rc1
+## Version 3.0.0-rc1
 - Use new versioning scheme for checking of runtime images
 
 ## Version 2.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 3.0.0-rc1
+## Version 3.0.0rc1
 - Use new versioning scheme for checking of runtime images
 
 ## Version 2.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 3.0.0rc1
+## Version 3.0.0rc2
 - Use new versioning scheme for checking of runtime images
 
 ## Version 2.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 3.0.0rc2
+## Version 3.0.0rc3
 - Use new versioning scheme for checking of runtime images
 
 ## Version 2.0.4

--- a/astronomer/airflow/version_check/plugin.py
+++ b/astronomer/airflow/version_check/plugin.py
@@ -10,7 +10,7 @@ from airflow.utils.sqlalchemy import UtcDateTime
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 
-__version__ = "3.0.0rc3"
+__version__ = "3.0.0"
 
 log = logging.getLogger(__name__)
 

--- a/astronomer/airflow/version_check/plugin.py
+++ b/astronomer/airflow/version_check/plugin.py
@@ -10,7 +10,7 @@ from airflow.utils.sqlalchemy import UtcDateTime
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 
-__version__ = "2.0.4"
+__version__ = "3.0.0rc3"
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
- Use new versioning scheme for checking of runtime images (#78)
- Move Version Check UI to runtime Middleware (#81)
- Remove FAB dependency (#82)