### PR TITLE
Fetch base_url from the modified config

### DIFF
--- a/astronomer/airflow/version_check/update_checks.py
+++ b/astronomer/airflow/version_check/update_checks.py
@@ -122,7 +122,7 @@ class CheckThread(threading.Thread, LoggingMixin):
         self.check_interval_secs = conf.getint("astronomer", "update_check_interval", fallback=24 * 60 * 60)
         self.check_interval = timedelta(seconds=self.check_interval_secs)
         self.request_timeout = conf.getint("astronomer", "update_check_timeout", fallback=60)
-        self.base_url = conf.get("webserver", "base_url")
+        self.base_url = conf.get("api", "base_url")
         self.runtime_version = get_runtime_version()
         self.update_url = conf.get(
             "astronomer", "update_url", fallback="https://updates.astronomer.io/astronomer-runtime"


### PR DESCRIPTION
In Airflow OSS config ``webserver.base_url`` has been renamed to ``api.base_url`` 
Reference: https://github.com/apache/airflow/commit/f40fb4af4e64601af836e2e47b4a87fc68c95fe4

This PR fixes the plugin to be compatible with the change.