### PR TITLE
Fix revision_heads_map version and migration hash in DBManager

### DIFF
--- a/astronomer/airflow/version_check/models/manager.py
+++ b/astronomer/airflow/version_check/models/manager.py
@@ -13,7 +13,7 @@ from astronomer.airflow.version_check.models.db import Base
 PACKAGE_DIR = Path(__file__).parents[1]
 
 _REVISION_HEADS_MAP: dict[str, str] = {
-    "3.1.0": "b5ad49d1f9b4",
+    "3.0.0": "c7f8e9a2b3d4",
 }
 
 
@@ -25,6 +25,7 @@ class VersionCheckDBManager(BaseDBManager):
     migration_dir = (PACKAGE_DIR / "migrations").as_posix()
     alembic_file = (PACKAGE_DIR / "alembic.ini").as_posix()
     supports_table_dropping = True
+    revision_heads_map = _REVISION_HEADS_MAP
 
     def create_db_from_orm(self):
         super().create_db_from_orm()


### PR DESCRIPTION
- Corrected version key to "3.0.0" and revision hash to "c7f8e9a2b3d4" in _REVISION_HEADS_MAP
- Set revision_heads_map on VersionCheckDBManager